### PR TITLE
Fix footer script iteration bug

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
 <script src="{{site.baseurl}}/assets/gitbook/custom-local.js"></script>
 
 {% if site.extra_footer_js %}
-    {%- for extra_js in site.extra_header_js -%}
+    {%- for extra_js in site.extra_footer_js -%}
         {%- assign starts_with = extra_js | slice: 0,4  -%}
         {% if starts_with == "http" %}
 <script src="{{ extra_js }}"></script>


### PR DESCRIPTION
## Summary
- Correct footer include to iterate over `extra_footer_js` instead of `extra_header_js`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68addffdcde88321890c9135d5ad9c22